### PR TITLE
Improve metadata: add descriptions, fix license identifier, fix date formats, update URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 10 year nominal yields on UK government bonds from the bank of England. The 10
 year government bond yield is considered a standard indicator of long-term
-interest rates. This is a direct extract from the Bank of [England IUAAMNPY
-series: "Annual average yield from British Government Securities, 10 year
-Nominal Par Yield"][boe].
+interest rates. This dataset contains both annual (IUAAMNPY) and quarterly (IUQAMNPY)
+average yield series from the Bank of England Statistical Interactive
+Database (IADB). See [Bank of England IADB][boe].
 
-[boe]: http://www.bankofengland.co.uk/boeapps/iadb/index.asp?Travel=NIxIRx&levels=1&XNotes=Y&C=DUS&G0Xtop.x=51&G0Xtop.y=7&XNotes2=Y&Nodes=X41514X41515X41516X41517X55047X76909X4051X4052X4128X33880X4053X4058&SectionRequired=I&HideNums=-1&ExtraInfo=true#BM
+[boe]: https://www.bankofengland.co.uk/boeapps/database/index.asp?Travel=NIxIRx&levels=1&XNotes=Y&C=DUS&G0Xtop.x=51&G0Xtop.y=7&XNotes2=Y&Nodes=X41514X41515X41516X41517X55047X76909X4051X4052X4128X33880X4053X4058&SectionRequired=I&HideNums=-1&ExtraInfo=true#BM
 
 ## Data
 
@@ -14,14 +14,14 @@ Data from Bank of England (series IUAAMNPY "Annual average yield from British
 Government Securities, 10 year Nominal Par Yield") with some minor processing
 (see scripts).
 
-Full information about the BoE Yields data may be found on the BoE website at [bankofengland official site](http://www.bankofengland.co.uk/statistics/Pages/iadb/notesiadb/Yields.aspx)
+Full information about the BoE Yields data may be found on the BoE website at [bankofengland official site](https://www.bankofengland.co.uk/statistics/details/further-details-about-yields-data)
 
 There are several relevant series:
 
 * 10y par yields Annual average - IUAAMNPY - Annual
-  * [www.bankofengland.co.uk](http://www.bankofengland.co.uk/boeapps/iadb/index.asp?Travel=NIxIRx&levels=1&XNotes=Y&G0Xtop.x=56&G0Xtop.y=10&C=DUS&XNotes2=Y&Nodes=X41514X41515X41516X41517X55047X76909X4051X4052X4128X33880X4053X4058&SectionRequired=I&HideNums=-1&ExtraInfo=true#BM)
+  * [www.bankofengland.co.uk](https://www.bankofengland.co.uk/boeapps/database/index.asp?Travel=NIxIRx&levels=1&XNotes=Y&G0Xtop.x=56&G0Xtop.y=10&C=DUS&XNotes2=Y&Nodes=X41514X41515X41516X41517X55047X76909X4051X4052X4128X33880X4053X4058&SectionRequired=I&HideNums=-1&ExtraInfo=true#BM)
   * 1984-present
-  * [Direct download URLs look like](http://www.bankofengland.co.uk/boeapps/iadb/fromshowcolumns.asp?csv.x=yes&SeriesCodes=IUMAMNPY&UsingCodes=Y&CSVF=TN&Datefrom=01/Jan/1963&Dateto=01/Jan/2015)
+  * [Direct download URLs look like](https://www.bankofengland.co.uk/boeapps/database/_iadb-FromShowColumns.asp?csv.x=yes&SeriesCodes=IUMAMNPY&UsingCodes=Y&CSVF=TN&Datefrom=01/Jan/1963&Dateto=01/Jan/2015)
 * There are also versions of this series at other granularities down to a day
   * Daily - IUDMNPY - Daily
   * Month average - IUMAMNPY - Monthly
@@ -61,7 +61,7 @@ use:
 > a user is acting in a manner contrary to the interests of other users of the
 > database e.g. excessive usage. [retrieved 2013-04-07]
 
-[tou]: http://www.bankofengland.co.uk/pages/disclaimer.aspx#Statistics
+[tou]: https://www.bankofengland.co.uk/legal
 
 However, the amounts of data provided in this dataset is so minimal as likely to fall
 below any threshold for Database Rights.

--- a/datapackage.json
+++ b/datapackage.json
@@ -4,14 +4,13 @@
   "hash": "afb93405823f15cba73152e45f2d0795",
   "licenses": [
     {
-      "id": "odc-pddl",
-      "name": "public_domain_dedication_and_license",
-      "path": "http://opendatacommons.org/licenses/pddl/"
+      "name": "ODC-PDDL-1.0",
+      "path": "https://opendatacommons.org/licenses/pddl/",
+      "title": "Open Data Commons Public Domain Dedication and License"
     }
   ],
   "name": "bond-yields-uk-10y",
   "profile": "data-package",
-  "readme": "<a className=\"gh-badge\" href=\"https://datahub.io/core/bond-yields-uk-10y\"><img src=\"https://badgen.net/badge/icon/View%20on%20datahub.io/orange?icon=https://datahub.io/datahub-cube-badge-icon.svg&label&scale=1.25\" alt=\"badge\" /></a>\n\n10 year nominal yields on UK government bonds from the bank of England. The 10\nyear government bond yield is considered a standard indicator of long-term\ninterest rates. This is a direct extract from the Bank of [England IUAAMNPY\nseries: \"Annual average yield from British Government Securities, 10 year\nNominal Par Yield\"][boe].\n\n[boe]: http://www.bankofengland.co.uk/boeapps/iadb/index.asp?Travel=NIxIRx&levels=1&XNotes=Y&C=DUS&G0Xtop.x=51&G0Xtop.y=7&XNotes2=Y&Nodes=X41514X41515X41516X41517X55047X76909X4051X4052X4128X33880X4053X4058&SectionRequired=I&HideNums=-1&ExtraInfo=true#BM\n\n## Data\n\nData from Bank of England (series IUAAMNPY \"Annual average yield from British\nGovernment Securities, 10 year Nominal Par Yield\") with some minor processing\n(see scripts).\n\nFull information about the BoE Yields data may be found on the BoE website at [bankofengland official site](http://www.bankofengland.co.uk/statistics/Pages/iadb/notesiadb/Yields.aspx)\n\nThere are several relevant series:\n\n* 10y par yields Annual average - IUAAMNPY - Annual\n  * [www.bankofengland.co.uk](http://www.bankofengland.co.uk/boeapps/iadb/index.asp?Travel=NIxIRx&levels=1&XNotes=Y&G0Xtop.x=56&G0Xtop.y=10&C=DUS&XNotes2=Y&Nodes=X41514X41515X41516X41517X55047X76909X4051X4052X4128X33880X4053X4058&SectionRequired=I&HideNums=-1&ExtraInfo=true#BM)\n  * 1984-present\n  * [Direct download URLs look like](http://www.bankofengland.co.uk/boeapps/iadb/fromshowcolumns.asp?csv.x=yes&SeriesCodes=IUMAMNPY&UsingCodes=Y&CSVF=TN&Datefrom=01/Jan/1963&Dateto=01/Jan/2015)\n* There are also versions of this series at other granularities down to a day\n  * Daily - IUDMNPY - Daily\n  * Month average - IUMAMNPY - Monthly\n  * End month - IUMMNPY - Monthly\n  * Quarterly average - IUQAMNPY - Quarterly\n  * End quarter - IUQMNPY - Quarterly\n  * Annual average - IUAAMNPY - Annual\n  * End year - IUAMNPY - Annual\n* 10y par gross redemption yield Annual average - IUAAAJLW - Annual\n  * 1984-present (not clear why this ends in 2007)\n\n## Preparation\n\nYou will need Python 3.6 or greater and dataflows library to run the script\n\nTo update the data run the process script locally:\n\n```\n# Install requirements\npip install -r scripts/requirements.txt\n\n# Run the script\npython scripts/bond_uk_flow.py\n```\n\n## License\n\nThe [Bank of England Terms of Use][tou] appear only to allow non-commercial\nuse:\n\n> Statistical Interactive Database (IADB) Terms and Conditions\n>\n> The content of the database is for general information only, and is provided\n> to users free of charge. Commercial use for financial gain is not permitted\n> without the express permission of the Bank of England.  The Bank of England\n> reserves the right to terminate or restrict user access if it determines that\n> a user is acting in a manner contrary to the interests of other users of the\n> database e.g. excessive usage. [retrieved 2013-04-07]\n\n[tou]: http://www.bankofengland.co.uk/pages/disclaimer.aspx#Statistics\n\nHowever, the amounts of data provided in this dataset is so minimal as likely to fall\nbelow any threshold for Database Rights.\n\nAs such the maintainers feel warranted in putting the dataset out under the\nPublic Domain Dedication and License but that they can, obviously, only license\n(or dedicate) material they control (or in which there are no rights).\n",
   "resources": [
     {
       "bytes": 3208,
@@ -34,9 +33,10 @@
       "schema": {
         "fields": [
           {
-            "format": "%Y-%m-%d",
+            "format": "default",
             "name": "Date",
-            "type": "date"
+            "type": "date",
+            "description": "Date of the last day of the quarter, in YYYY-MM-DD format."
           },
           {
             "decimalChar": ".",
@@ -50,7 +50,8 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Quarterly average nominal yields on 10-year UK government bonds (Bank of England series IUQAMNPY), from Q1 1984 to present."
     },
     {
       "bytes": 813,
@@ -73,9 +74,10 @@
       "schema": {
         "fields": [
           {
-            "format": "%Y-%m-%d",
+            "format": "default",
             "name": "Year",
-            "type": "date"
+            "type": "date",
+            "description": "Year-end date (December 31) for the annual observation, in YYYY-MM-DD format."
           },
           {
             "decimalChar": ".",
@@ -89,13 +91,14 @@
         "missingValues": [
           ""
         ]
-      }
+      },
+      "description": "Annual average nominal yields on 10-year UK government bonds (Bank of England series IUAAMNPY), from 1984 to present."
     }
   ],
   "sources": [
     {
       "name": "Bank of England",
-      "path": "http://www.bankofengland.co.uk/boeapps/iadb/index.asp?Travel=NIxIRx&levels=1&XNotes=Y&C=DUS&G0Xtop.x=51&G0Xtop.y=7&XNotes2=Y&Nodes=X41514X41515X41516X41517X55047X76909X4051X4052X4128X33880X4053X4058&SectionRequired=I&HideNums=-1&ExtraInfo=true#BM",
+      "path": "https://www.bankofengland.co.uk/boeapps/database/index.asp?Travel=NIxIRx&levels=1&XNotes=Y&C=DUS&G0Xtop.x=51&G0Xtop.y=7&XNotes2=Y&Nodes=X41514X41515X41516X41517X55047X76909X4051X4052X4128X33880X4053X4058&SectionRequired=I&HideNums=-1&ExtraInfo=true#BM",
       "title": "Bank of England"
     }
   ],
@@ -116,5 +119,6 @@
       "specType": "simple",
       "title": "Average yield from British Government Securities, 10 year Nominal Par Yield"
     }
-  ]
+  ],
+  "description": "Annual and quarterly average nominal yields on 10-year UK government bonds, sourced from Bank of England series IUAAMNPY (annual) and IUQAMNPY (quarterly), from 1984 to present."
 }


### PR DESCRIPTION
- Add package-level `description`
- Fix `licenses[0].name` to standard identifier `ODC-PDDL-1.0`; add `title`; update license path to HTTPS
- Update `sources[0].path` from deprecated `/boeapps/iadb/` to `/boeapps/database/` and HTTP→HTTPS
- Remove `readme` property from `datapackage.json` (belongs in README.md only)
- Add `description` to both resources (`quarterly`, `annual`)
- Add `description` to `Date` and `Year` fields; fix `format` from `"%Y-%m-%d"` to `"default"` (Frictionless canonical for ISO 8601)
- README: update all stale/redirecting BoE URLs; fix broken Terms of Use link (404); fix opening paragraph to mention both annual and quarterly series