### PR TITLE
Add frictionless validate to CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -48,6 +48,11 @@ jobs:
         source venv/bin/activate
         python scripts/bond_uk_flow.py
 
+    - name: Validate datapackage
+      run: |
+        source venv/bin/activate
+        frictionless validate datapackage.json
+
     - name: Configure Git
       run: |
         git config --global user.email "${{ env.CI_COMMIT_EMAIL }}"


### PR DESCRIPTION
## Changes

Added a `frictionless validate datapackage.json` step to `.github/workflows/actions.yml`, running after the data script and before the git commit step.

**Why:** The audit found that no workflow validated the descriptor against the data. Without this check, a schema change (e.g. added/removed column, type change) could be committed without detection, causing downstream consumers to fail silently.

**How it works:** If `frictionless validate` returns a non-zero exit code (validation errors), the workflow step fails and git will not commit or push the broken state.

Note: `frictionless` is already installed as part of `scripts/requirements.txt` (pulled in transitively via `dataflows`), so no additional `pip install` step is needed.